### PR TITLE
Use yarn to lint instead of npm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run lint
+        cache: 'yarn'
+    - run: yarn ci
+    - run: yarn lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,5 +22,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn ci
+    - run: yarn install
     - run: yarn lint


### PR DESCRIPTION
Switch to yarn to not fail CI runs when linting
Fixes #1 